### PR TITLE
Make permission check more lenient.

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -179,15 +179,21 @@ function check_venv()
             file_owner="$(/usr/bin/stat -f %u "$venv_path")"
             file_permissions="$(/usr/bin/stat -f %OLp "$venv_path")"
         fi
+        if [[ -d "$venv_path" ]]; then
+            default_permissions=777
+        else
+            default_permissions=666
+        fi
+        default_permissions="$(printf %o "$((~8#$(umask) & 8#$default_permissions))")"
 
         if [[ "$file_owner" != "$(id -u)" ]]; then
             printf "AUTOSWITCH WARNING: Virtualenv will not be activated\n\n"
             printf "Reason: Found a $AUTOSWITCH_FILE file but it is not owned by the current user\n"
             printf "Change ownership of ${PURPLE}$venv_path${NORMAL} to ${PURPLE}'$USER'${NORMAL} to fix this\n"
-        elif ! [[ "$file_permissions" =~ ^[64][04][04]$ ]]; then
+        elif [[ "$file_permissions" != "$default_permissions" ]]; then
             printf "AUTOSWITCH WARNING: Virtualenv will not be activated\n\n"
-            printf "Reason: Found a $AUTOSWITCH_FILE file with weak permission settings ($file_permissions).\n"
-            printf "Run the following command to fix this: ${PURPLE}\"chmod 600 $venv_path\"${NORMAL}\n"
+            printf "Reason: Found a $AUTOSWITCH_FILE file with non-default permission settings ($file_permissions).\n"
+            printf "Run the following command to fix this: ${PURPLE}\"chmod $default_permissions $venv_path\"${NORMAL}\n"
         else
             if [[ "$venv_path" == *"/Pipfile" ]]; then
                 if type "pipenv" > /dev/null && _activate_pipenv; then


### PR DESCRIPTION
Instead of enforcing an arbitrary permission policy, check permissions against  current umask.

If permissions are changed from the default, this might be a hint that something shady is going on.

Resolves #152.